### PR TITLE
ci: bump qavor container image to node26-0.3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # image: kubevious/node-builder:26-v1
-      image: rubenhak/qavor:node26-0.3.3
+      image: rubenhak/qavor:node26-0.3.7
     permissions:
       # id-token: write lets npm mint an OIDC token for trusted publishing.
       # contents: write lets the release commit and tag get pushed back.


### PR DESCRIPTION
## Summary
- Bump CI container image from `rubenhak/qavor:node26-0.3.3` to `rubenhak/qavor:node26-0.3.7`

## Test plan
- [ ] CI run passes with new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6nGkBFpWEwZdYBHTR2Se8